### PR TITLE
Add CSV GUI tool

### DIFF
--- a/csv/README.md
+++ b/csv/README.md
@@ -1,0 +1,50 @@
+# CSV Product Analyzer
+
+Esta carpeta contiene un pequeño script para analizar un archivo CSV de productos. El script lee una columna de descripciones y extrae, mediante expresiones regulares, el color y el tamaño de cada producto.
+
+## Requisitos
+
+- Python 3.8+
+- `pandas`
+
+Instala las dependencias con:
+
+```bash
+pip install pandas
+```
+
+## Uso
+
+1. Coloca tu archivo `productos.csv` (o el nombre que corresponda) en esta carpeta.
+2. Ejecuta el script indicando la ruta del CSV:
+
+```bash
+python analyze.py productos.csv --salida productos_con_parametros.csv --columna descripcion
+```
+
+La columna de descripciones debe llamarse `descripcion` o el nombre que indiques mediante `--columna`.
+
+El script generará un nuevo archivo con las columnas `color` y `tamano` agregadas.
+
+## Interfaz Gráfica
+
+Para quienes prefieran una herramienta visual, `analyze_gui.py` ofrece una pequeña interfaz basada en `tkinter`.
+
+Ejecuta el script así:
+
+```bash
+python analyze_gui.py
+```
+
+Selecciona el archivo CSV de entrada, elige la ubicación del archivo de salida y la columna que contiene las descripciones. Al finalizar se mostrará un mensaje con la ruta del nuevo archivo.
+
+### Crear un ejecutable
+
+Si deseas generar un ejecutable sin depender de Python instalado, puedes usar `pyinstaller` (o herramienta similar):
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile analyze_gui.py
+```
+
+El ejecutable resultante estará en la carpeta `dist/`.

--- a/csv/analyze.py
+++ b/csv/analyze.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import re
+import argparse
+
+PARAM_COLORS = [
+    'rojo', 'azul', 'verde', 'negro', 'blanco',
+    'amarillo', 'gris', 'marron', 'naranja', 'rosa'
+]
+
+SIZE_PATTERN = re.compile(r'(\d+(?:x\d+)*\s*(?:cm|mm|m))', re.I)
+COLOR_PATTERN = re.compile(r'(' + '|'.join(PARAM_COLORS) + r')', re.I)
+
+
+def extraer_parametros(descripcion):
+    """Extrae color y tamaño de la descripcion del producto."""
+    if not isinstance(descripcion, str):
+        return None, None
+    color_match = COLOR_PATTERN.search(descripcion)
+    size_match = SIZE_PATTERN.search(descripcion)
+    color = color_match.group(1).lower() if color_match else None
+    size = size_match.group(1) if size_match else None
+    return color, size
+
+
+def procesar_csv(ruta_entrada, ruta_salida, columna_desc='descripcion'):
+    """Procesa el CSV de productos y guarda uno nuevo con parametros."""
+    df = pd.read_csv(ruta_entrada)
+    if columna_desc not in df.columns:
+        raise ValueError(f"La columna '{columna_desc}' no existe en el CSV")
+    df[['color', 'tamano']] = df[columna_desc].apply(
+        lambda desc: pd.Series(extraer_parametros(desc))
+    )
+    df.to_csv(ruta_salida, index=False)
+    print(f"Archivo guardado en {ruta_salida}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Extrae parametros de productos desde un CSV')
+    parser.add_argument('entrada', help='Ruta del CSV de entrada')
+    parser.add_argument('--salida', default='productos_con_parametros.csv', help='Ruta del CSV resultante')
+    parser.add_argument('--columna', default='descripcion', help='Nombre de la columna con descripciones')
+    args = parser.parse_args()
+    procesar_csv(args.entrada, args.salida, args.columna)

--- a/csv/analyze_gui.py
+++ b/csv/analyze_gui.py
@@ -1,0 +1,59 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+import pandas as pd
+
+class App(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("CSV Product Analyzer")
+        self.geometry("400x200")
+
+        tk.Label(self, text="CSV de entrada:").pack(anchor='w', padx=10, pady=5)
+        self.entry_input = tk.Entry(self, width=40)
+        self.entry_input.pack(anchor='w', padx=10)
+        tk.Button(self, text="Buscar", command=self.browse_input).pack(anchor='w', padx=10, pady=2)
+
+        tk.Label(self, text="CSV de salida:").pack(anchor='w', padx=10, pady=5)
+        self.entry_output = tk.Entry(self, width=40)
+        self.entry_output.pack(anchor='w', padx=10)
+        tk.Button(self, text="Buscar", command=self.browse_output).pack(anchor='w', padx=10, pady=2)
+
+        tk.Label(self, text="Columna de descripcion:").pack(anchor='w', padx=10, pady=5)
+        self.entry_column = tk.Entry(self, width=40)
+        self.entry_column.insert(0, 'descripcion')
+        self.entry_column.pack(anchor='w', padx=10)
+
+        tk.Button(self, text="Procesar", command=self.run).pack(pady=10)
+
+    def browse_input(self):
+        path = filedialog.askopenfilename(filetypes=[('CSV files', '*.csv')])
+        if path:
+            self.entry_input.delete(0, tk.END)
+            self.entry_input.insert(0, path)
+
+    def browse_output(self):
+        path = filedialog.asksaveasfilename(defaultextension='.csv', filetypes=[('CSV files', '*.csv')])
+        if path:
+            self.entry_output.delete(0, tk.END)
+            self.entry_output.insert(0, path)
+
+    def run(self):
+        entrada = self.entry_input.get()
+        salida = self.entry_output.get() or 'productos_con_parametros.csv'
+        columna = self.entry_column.get() or 'descripcion'
+        if not entrada:
+            messagebox.showerror('Error', 'Debes seleccionar un archivo de entrada')
+            return
+        try:
+            df = pd.read_csv(entrada)
+            if columna not in df.columns:
+                raise ValueError(f"La columna '{columna}' no existe en el CSV")
+            df[['color', 'tamano']] = df[columna].apply(lambda d: pd.Series(extraer_parametros(d)))
+            df.to_csv(salida, index=False)
+            messagebox.showinfo('Exito', f'Archivo guardado en {salida}')
+        except Exception as e:
+            messagebox.showerror('Error', str(e))
+
+if __name__ == '__main__':
+    app = App()
+    app.mainloop()

--- a/csv/productos.csv
+++ b/csv/productos.csv
@@ -1,0 +1,4 @@
+id,descripcion,precio
+1,Camiseta roja talla M 30x40 cm,9.99
+2,Pantalon azul 100x50 cm,19.99
+3,Zapatos negros de cuero 40x20 cm,29.99


### PR DESCRIPTION
## Summary
- add simple GUI frontend for the CSV analyzer
- document how to use the GUI and create a standalone executable

## Testing
- `python3 csv/analyze.py csv/productos.csv --salida csv/productos_con_parametros.csv` *(fails: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68601c9438dc8331ac2429f2e0b2c5dc